### PR TITLE
add `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "yank",
+  "repo": "mptre/yank",
+  "version": "v0.4.0",
+  "install": "make install"
+}


### PR DESCRIPTION
Having a `package.json` with an `install` key enables clib(1)
installation support.

See more at https://github.com/clibs/clib
