### PR TITLE
Use older save/restore cursor codes

### DIFF
--- a/yank.c
+++ b/yank.c
@@ -28,8 +28,8 @@
 #define T_KEY_LEFT            "\033[D"
 #define T_KEY_RIGHT           "\033[C"
 #define T_KEY_UP              "\033[A"
-#define T_RESTORE_CURSOR      "\033[u"
-#define T_SAVE_CURSOR         "\033[s"
+#define T_RESTORE_CURSOR      "\0338"
+#define T_SAVE_CURSOR         "\0337"
 
 #define CONTROL(c) (c ^ 0x40)
 #define MAX(x, y) ((x) > (y) ? (x) : (y))


### PR DESCRIPTION
`\E7` and `\E8` are older, more widely-supported codes for saving and
restoring the cursor position than `\E[s` and `\E[u`. In lieu of using
ncurses or some other library to get the current terminal's escape
codes, use the older codes for the time being.

Related to #22.
