### PR TITLE
Store a copy of the pattern argument

### DIFF
--- a/yank.c
+++ b/yank.c
@@ -430,7 +430,8 @@ main(int argc, char *argv[])
 			break;
 		case 'g':
 			free(pat);
-			pat = optarg;
+			if ((pat = strdup(optarg)) == NULL)
+				err(1, NULL);
 			rflags |= REG_NEWLINE;
 			break;
 		case 'i':


### PR DESCRIPTION
Otherwise, it might end up being freed during odd invocations like the following:

```sh
  $ yank -g foo -l </dev/null
```

/cc @t6 