### PR TITLE
Add openSUSE installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ $ pkg install yank
 $ pkg_add yank
 ```
 
+### openSUSE
+
+```
+zypper install yank
+```
+
 ### From source
 
 The install directory defaults to `/usr/local`:


### PR DESCRIPTION
I maintain the package for `yank` on openSUSE.