### PR TITLE
Allow overrides in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 VERSION=	1.1.0
 
-YANKCMD=	xsel
+YANKCMD?=	xsel
 
-PREFIX=		/usr/local
-MANPREFIX=	${PREFIX}/share/man
+PREFIX?=	/usr/local
+MANPREFIX?=	${PREFIX}/share/man
 
-PROG=	yank
+PROG?=	yank
 OBJS=	yank.o
 
 INSTALL_PROGRAM=	install -s -m 0755


### PR DESCRIPTION
Hello,
Some builds will prefer a different install path. Relatedly, Debian prefers `PROG=yank-cli` for their own reason. This patch allows changing these without editing source.