### PR TITLE
Add snapcraft support for building snaps of yank

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,14 +3,14 @@ base: core18
 version: git
 summary: Yank terminal output to clipboard 
 description: |
-  The yank(1) utility reads input from stdin and display a selection
+  The yank utility reads input from stdin and display a selection
   interface that allows a field to be selected and copied to the clipboard.
   Fields are either recognized by a regular expression using the -g option
   or by splitting the input on a delimiter sequence using the -d option.
   Using the arrow keys will move the selected field. The interface supports
   several Emacs and Vi like key bindings, consult the man page for further
   reference. Pressing the return key will invoke the yank command and write
-  the selected field to its stdin. The yank command defaults to xsel(1) but
+  the selected field to its stdin. The yank command defaults to xsel but
   could be anything that accepts input on stdin. When invoking yank, everything
   supplied after the -- option will be used as the yank command.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,3 +31,5 @@ apps:
     command: usr/local/bin/yank
     plugs:
       - x11
+      - home
+      - removable-media

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: yank
+base: core18
+version: git
+summary: Yank terminal output to clipboard 
+description: |
+  The yank(1) utility reads input from stdin and display a selection
+  interface that allows a field to be selected and copied to the clipboard.
+  Fields are either recognized by a regular expression using the -g option
+  or by splitting the input on a delimiter sequence using the -d option.
+  Using the arrow keys will move the selected field. The interface supports
+  several Emacs and Vi like key bindings, consult the man page for further
+  reference. Pressing the return key will invoke the yank command and write
+  the selected field to its stdin. The yank command defaults to xsel(1) but
+  could be anything that accepts input on stdin. When invoking yank, everything
+  supplied after the -- option will be used as the yank command.
+
+grade: stable
+confinement: strict
+
+parts:
+  yank:
+    plugin: make
+    source: .
+    stage-packages:
+      - xsel
+    build-packages:
+      - gcc
+
+apps:
+  yank:
+    command: usr/local/bin/yank
+    plugs:
+      - x11


### PR DESCRIPTION
This pull request enables creation of a snap package of yank.The single snap (built for many architectures) in the Snap Store will be installable on numerous popular Linux distributions with no changes. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

I appreciate yank is already widely available in numerous repositories, which is fantastic. One benefit of being available as a snap, is it allows one up-to-date package to be used across many Linux distributions. So users who stick on older LTS releases of Linux distros by choice or policy, can still get the latest version of your software. 

If you're willing to publish this under the yank project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the yank name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of yank, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via a third party CI system such as travis or circle-ci.

The storefront also supports animated gifs, which we find helps users make decisions about whether to install a snap or not :)

I appreciate you may not be aware of snaps and snapcraft, and I’d of course be happy to answer any questions you may have. 
