### PR TITLE
Don't clear screen after command completion

### DIFF
--- a/yank.1
+++ b/yank.1
@@ -59,6 +59,8 @@ Use the default delimiters except for space, see
 Prints version.
 .It Fl x
 Use alternate screen.
+.It Fl X
+Don't clear the screen after completion.
 .It Fl - Ar command Op Ar argument ...
 Use
 .Ar command

--- a/yank.c
+++ b/yank.c
@@ -405,7 +405,7 @@ tmain(void)
 static void
 usage(void)
 {
-	fprintf(stderr, "usage: yank [-lx | -v] [-d delim] [-g pattern [-i]] "
+	fprintf(stderr, "usage: yank [-lxX | -v] [-d delim] [-g pattern [-i]] "
 	    "[-- command [args]]\n");
 	exit(2);
 }

--- a/yank.c
+++ b/yank.c
@@ -64,6 +64,7 @@ static struct {
 	int		rfd;
 	int		wfd;
 	int		ca;	/* use alternate screen */
+	int		clear;
 	struct termios	attr;
 } tty;
 
@@ -280,8 +281,10 @@ tsetup(void)
 static void
 tend(void)
 {
-	tputs(T_RESTORE_CURSOR);
-	tputs(T_CLR_EOS);
+	if (tty.clear) {
+		tputs(T_RESTORE_CURSOR);
+		tputs(T_CLR_EOS);
+	}
 	tputs(T_CURSOR_VISIBLE);
 	if (tty.ca)
 		tputs(T_EXIT_CA_MODE);
@@ -422,7 +425,8 @@ main(int argc, char *argv[])
 #endif
 
 	pat = strtopat(" ");
-	while ((c = getopt(argc, argv, "ilvxd:g:")) != -1)
+	tty.clear = 1; /* by default screen is cleared */
+	while ((c = getopt(argc, argv, "ilvxXd:g:")) != -1)
 		switch (c) {
 		case 'd':
 			free(pat);
@@ -446,6 +450,9 @@ main(int argc, char *argv[])
 			exit(0);
 		case 'x':
 			tty.ca = 1;
+			break;
+		case 'X':
+			tty.clear = 0;
 			break;
 		default:
 			usage();


### PR DESCRIPTION
I haven't find any option to do that. And quite often I'm using `yank` and I want to keep the output of the piped command in my terminal.

This PR, adds a new flag: `X`. When this flag is used the output is not
cleared after yank is completing.