### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ $ yaourt -S yank
 
 ### Debian
 
-On testing and unstable:
-
 ```sh
 $ sudo apt-get install yank
 ```


### PR DESCRIPTION
Debian has now yank in all its releases.
```sh
rmadison yank
yank       | 0.8.0-1       | oldstable      | source, amd64, arm64, armel, armhf, i386, mips, mips64el, mipsel, ppc64el, s390x
yank       | 1.1.0-2       | stable         | source, amd64, arm64, armel, armhf, i386, mips, mips64el, mipsel, ppc64el, s390x
yank       | 1.2.0-1       | testing        | source, amd64, arm64, armel, armhf, i386, mips64el, mipsel, ppc64el, s390x
yank       | 1.2.0-1       | unstable       | source, amd64, arm64, armel, armhf, i386, mips64el, mipsel, ppc64el, s390x
yank       | 1.2.0-1       | unstable-debug | source
```