### PR TITLE
add opt-in selection of one and only field

### DIFF
--- a/yank.1
+++ b/yank.1
@@ -6,7 +6,7 @@
 .Nd yank terminal output to clipboard
 .Sh SYNOPSIS
 .Nm
-.Op Fl ilxv
+.Op Fl 1ilxv
 .Op Fl d Ar delim
 .Op Fl g Ar pattern
 .Op Fl - Ar command Op Ar argument ...
@@ -39,6 +39,10 @@ see
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl 1
+If only one field is recognized, select it and invoke
+.Ar command
+without displaying the selection interface.
 .It Fl d Ar delim
 All input characters not present in
 .Ar delim

--- a/yank.c
+++ b/yank.c
@@ -405,7 +405,7 @@ tmain(void)
 static void
 usage(void)
 {
-	fprintf(stderr, "usage: yank [-ilxv] [-d delim] [-g pattern] "
+	fprintf(stderr, "usage: yank [-1ilxv] [-d delim] [-g pattern] "
 	    "[-- command [args]]\n");
 	exit(2);
 }
@@ -415,6 +415,7 @@ main(int argc, char *argv[])
 {
 	const struct field *field;
 	char *pat;
+	int one = 0;
 	int rflags = REG_EXTENDED;
 	int c, i;
 
@@ -426,8 +427,11 @@ main(int argc, char *argv[])
 #endif
 
 	pat = strtopat(" ");
-	while ((c = getopt(argc, argv, "ilvxd:g:")) != -1)
+	while ((c = getopt(argc, argv, "1ilvxd:g:")) != -1)
 		switch (c) {
+		case '1':
+			one = 1;
+			break;
 		case 'd':
 			free(pat);
 			pat = strtopat(optarg);
@@ -469,7 +473,10 @@ main(int argc, char *argv[])
 
 	input();
 	tsetup();
-	field = tmain();
+	if (one && f.nmemb == 1)
+		field = &f.v[0];
+	else
+		field = tmain();
 	tend();
 	if (field == NULL)
 		return 1;


### PR DESCRIPTION
If only one field is recognized, select it and invoke the command without
displaying the selection interface.

Feature requested by Mikael Elkiaer who also pointed out that fzf[1] already has
a similar feature using the same `-1` option.

Resolves #64

[1] https://man.archlinux.org/man/fzf.1.en#Scripting