### PR TITLE
Update Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,8 @@ terminal agnostic solution.
 
 ### Arch Linux
 
-On AUR:
-
 ```sh
-$ yaourt -S yank
+$ pacman -S yank
 ```
 
 ### Debian


### PR DESCRIPTION
`yank` is moved to the community repository: https://archlinux.org/packages/community/x86_64/yank/
